### PR TITLE
Making project_field and project_field_value optional

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -133,14 +133,14 @@ const updateProjectNextItemField: (params: {
   item: string
   targetField: string
   targetFieldValue: string
-}) => Promise<void> = async ({
+}) => Promise<void> = ({
   gql,
   project,
   item,
   targetField,
   targetFieldValue,
 }) => {
-  await gql(
+  return gql(
     `
     mutation (
       $project: ID!

--- a/src/core.ts
+++ b/src/core.ts
@@ -100,16 +100,20 @@ const resolveProjectTargetField: (params: {
   }
 }
 
-type CreateItemResult = {
+type CreatedProjectItemForIssue = {
   addProjectNextItem: { projectNextItem: { id: string } }
 }
 
-const createItem: (params: {
+const createProjectItemForIssue: (params: {
   gql: typeof OctokitGraphQL
   projectId: string
   issueNodeId: string
-}) => Promise<CreateItemResult> = ({ gql, projectId, issueNodeId }) => {
-  return gql<CreateItemResult>(
+}) => Promise<CreatedProjectItemForIssue> = ({
+  gql,
+  projectId,
+  issueNodeId,
+}) => {
+  return gql<CreatedProjectItemForIssue>(
     `
     mutation($project: ID!, $issue: ID!) {
       addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
@@ -186,7 +190,7 @@ export const syncIssue = async ({
         })
       : null
 
-  const createItemResult = await createItem({
+  const createdProjectItemForIssue = await createProjectItemForIssue({
     gql,
     projectId: projectData.organization.projectNext.id,
     issueNodeId: issue.nodeId,
@@ -201,7 +205,7 @@ export const syncIssue = async ({
     await updateProjectNextItemField({
       gql,
       project: projectData.organization.projectNext.id,
-      item: createItemResult.addProjectNextItem.projectNextItem.id,
+      item: createdProjectItemForIssue.addProjectNextItem.projectNextItem.id,
       targetField: targetField.targetFieldId,
       targetFieldValue: targetField.targetValueId,
     })

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -12,6 +12,7 @@ import { Context, IssueToProjectFieldRule } from "./types"
 enum ApiVersion {
   v1 = "v1",
 }
+
 const getApiRoute = (version: ApiVersion, route: string) => {
   return `/api/${version}/${route}`
 }
@@ -286,10 +287,15 @@ export const setupApi = (
     >
   >().keys({
     project_number: Joi.number().required(),
-    project_field: Joi.string().required(),
-    project_field_value: Joi.string().required(),
+    project_field: Joi.string(),
+    project_field_value: Joi.string().when("project_field", {
+      is: Joi.exist(),
+      then: Joi.required(),
+      otherwise: Joi.forbidden(),
+    }),
     filter: Joi.string(),
   })
+
   setupRoute(
     "post",
     ApiVersion.v1,

--- a/src/server/migrations/1651166162160_field_becomes_optional.ts
+++ b/src/server/migrations/1651166162160_field_becomes_optional.ts
@@ -1,0 +1,29 @@
+import type { MigrationBuilder } from "node-pg-migrate"
+
+const issueToProjectFieldRuleTable = "issue_to_project_field_rule"
+const projectField = "project_field"
+const projectFieldValue = "project_field_value"
+
+export const up = async (pgm: MigrationBuilder) => {
+  pgm.alterColumn(issueToProjectFieldRuleTable, projectField, {
+    allowNull: true,
+  })
+  pgm.alterColumn(issueToProjectFieldRuleTable, projectFieldValue, {
+    allowNull: true,
+  })
+}
+
+export const down = async (pgm: MigrationBuilder) => {
+  pgm.sql(`
+    DELETE FROM ${issueToProjectFieldRuleTable} 
+    WHERE 
+      ${projectField} IS NULL 
+      OR ${projectFieldValue} IS NULL
+  `)
+  pgm.alterColumn(issueToProjectFieldRuleTable, projectField, {
+    allowNull: false,
+  })
+  pgm.alterColumn(issueToProjectFieldRuleTable, projectFieldValue, {
+    allowNull: false,
+  })
+}


### PR DESCRIPTION
If a rule without project_field exists, the issue will created without a
status.
If project_field is provided, project_field_value would be mandatory too

Related to https://github.com/paritytech/github-issue-sync/issues/14