### PR TITLE
Replaced trivy for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # @types/node should be bumped manually once we change the Node.js version used
+      - dependency-name: "@types/node"
+      - dependency-name: "*"
+        # Ignore minor/patch upgrades; only bother with opening the upgrade PR
+        # when a new major release comes out; security updates are nevertheless
+        # unaffected by this setting and will continue to work.
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,13 +62,6 @@ lint:
     # TODO: Use pre-commit run --all
     - yarn lint
 
-security-scan:
-  <<:                              *common-refs
-  stage:                           test
-  image:                           aquasec/trivy:latest
-  script:
-    - trivy fs .
-
 # template task for building and pushing an image
 .build-push-docker-image:          &build-push-docker-image
   stage:                           build


### PR DESCRIPTION
It seems `trivy` is not the best option to analyze our repository as it [doesn't differ production dependencies from dev dependencies for yarn projects](https://github.com/aquasecurity/trivy/issues/90).

As recommended by @mutantcornholio in #30 I had replaced this check in favor of Dependabot as it can differ production dependencies from dev dependencies.

This PR closes #31.