### PR TITLE
Disable major dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,4 +12,4 @@ updates:
         # Ignore minor/patch upgrades; only bother with opening the upgrade PR
         # when a new major release comes out; security updates are nevertheless
         # unaffected by this setting and will continue to work.
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]


### PR DESCRIPTION
This will only allow security updates

Following updates are major updates, which aren't really necessary to do, and definitely not something you would like dependabot to do automatically  

See following PRs: https://github.com/paritytech/github-issue-sync/pull/35, https://github.com/paritytech/github-issue-sync/pull/34, https://github.com/paritytech/github-issue-sync/pull/33  