### PR TITLE
Excluding semver-major from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       # @types/node should be bumped manually once we change the Node.js version used
       - dependency-name: "@types/node"
       - dependency-name: "*"
-        # Ignore minor/patch upgrades; only bother with opening the upgrade PR
-        # when a new major release comes out; security updates are nevertheless
-        # unaffected by this setting and will continue to work.
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
+        # Ignore version upgrades.
+        # Security updates are nevertheless. unaffected by this setting and will continue to work.
+        update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]


### PR DESCRIPTION
There's little point in creating PRs when new major versions come out, as it usually will include breaking changes.  
Also, keeping versions aligned between our internal dependencies is probably a better practice than having all latest major versions of dependencies deployed to all services.