### PR TITLE
fix: updated GraphQL queries to V2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
         # Ignore version upgrades.
         # Security updates are nevertheless. unaffected by this setting and will continue to work.
         update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    allow:
+      - dependency-name: "@octokit/graphql-schema"

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ yarn-error.log
 
 .idea
 .DS_Store
+examples

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@octokit/rest": "^19.0.5"
   },
   "devDependencies": {
+    "@octokit/graphql-schema": "^12.41.1",
     "@types/jest": "^29.2.5",
     "jest": "^29.3.1",
     "jest-mock-extended": "^3.0.1",

--- a/src/github/issueKit.ts
+++ b/src/github/issueKit.ts
@@ -12,7 +12,7 @@ export class IssueApi implements IIssues {
     return issueData.data.state === "open" ? "open" : "closed";
   }
 
-  async getAllIssuesId(excludeClosed: boolean): Promise<Issue[]> {
+  async getAllIssues(excludeClosed: boolean): Promise<Issue[]> {
     const allIssues = await this.octokit.rest.issues.listForRepo({
       ...this.repoData,
       state: excludeClosed ? "open" : "all",

--- a/src/github/projectKit.ts
+++ b/src/github/projectKit.ts
@@ -39,7 +39,7 @@ export class ProjectKit implements IProjectApi {
     private readonly repoData: Repository,
     private readonly projectNumber: number,
     private readonly logger: ILogger,
-  ) { }
+  ) {}
 
   /*   changeIssueStateInProject(issueCardId: number, state: "todo" | "in progress" | "blocked" | "done"): Promise<void> {
       return this.gql(

--- a/src/github/projectKit.ts
+++ b/src/github/projectKit.ts
@@ -25,20 +25,24 @@ mutation($project: ID!, $issue: ID!) {
 }
 `;
 
-export const UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY: string = `
+export const UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY: string = `
 mutation (
   $project: ID!
   $item: ID!
   $targetField: ID!
   $targetFieldValue: String!
 ) {
-  updateProjectNextItemField(input: {
-    projectId: $project
-    itemId: $item
-    fieldId: $targetField
-    value: $targetFieldValue
-  }) {
-    projectNextItem {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $project
+      itemId: $item
+      fieldId: $targetField
+      value: {
+        singleSelectOptionId: $targetFieldValue
+        }
+      }
+    ) {
+    projectV2Item {
       id
     }
   }
@@ -113,14 +117,13 @@ export class ProjectKit implements IProjectApi {
     }
   }
 
-  // step three
   async updateProjectNextItemField(
     project: string,
     item: string,
     targetField: string,
     targetFieldValue: string,
   ): Promise<void> {
-    await this.gql(UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY, { project, item, targetField, targetFieldValue });
+    await this.gql(UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY, { project, item, targetField, targetFieldValue });
   }
 
   async assignIssueToProject(issue: Issue, projectId: string): Promise<boolean> {

--- a/src/github/projectKit.ts
+++ b/src/github/projectKit.ts
@@ -49,23 +49,6 @@ mutation (
 }
 `;
 
-interface ProjectData {
-  organization: {
-    projectV2: NodeData;
-    // {
-    //   id: string;
-    //   title: string;
-    //   // fields: {
-    //   //   nodes: {
-    //   //     id: string;
-    //   //     name: string;
-    //   //     settings?: string | null;
-    //   //   }[];
-    //   // };
-    // };
-  };
-}
-
 /**
  * Instance that manages the GitHub's project api
  * ? Octokit.js doesn't support Project v2 API yet so we need to use graphQL
@@ -103,7 +86,7 @@ export class ProjectKit implements IProjectApi {
 
     try {
       // Source: https://docs.github.com/en/graphql/reference/objects#projectnext
-      const projectData = await this.gql<ProjectData>(PROJECT_V2_QUERY, {
+      const projectData = await this.gql<{ organization: { projectV2: NodeData } }>(PROJECT_V2_QUERY, {
         organization: this.repoData.owner,
         number: this.projectNumber,
       });

--- a/src/github/projectKit.ts
+++ b/src/github/projectKit.ts
@@ -85,7 +85,7 @@ export class ProjectKit implements IProjectApi {
     }
 
     try {
-      // Source: https://docs.github.com/en/graphql/reference/objects#projectnext
+      // Source: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects#using-variables
       const projectData = await this.gql<{ organization: { projectV2: NodeData } }>(PROJECT_V2_QUERY, {
         organization: this.repoData.owner,
         number: this.projectNumber,

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -5,10 +5,15 @@ export type Issue = { number: number; node_id: string };
 export interface IProjectApi {
   /**
    * Assign an issue to a project
-   * @param issueNodeId The issue node_id (which differs from the issue id)
-   * @param projectId The project id (found in github.com/repo/projects/<ID>)
+   * @param issue The issue object which has the number and the node_id
    */
   assignIssue(issue: Issue): Promise<boolean>;
+
+  /**
+   * Assign several issues to a project
+   * @param issues The issue object collection which has the number and the node_id
+   */
+  assignIssues(issues: Issue[]): Promise<boolean[]>;
   // getProjectIdFromIssue(issueId: number): Promise<number>;
   // changeIssueStateInProject(issueId: number, state: "todo" | "in progress" | "blocked" | "done"): Promise<boolean>;
 }
@@ -24,7 +29,7 @@ export interface IIssues {
    * Returns the node_id for all the issues available in the repository
    * @param includeClosed exclude issues which are closed from the data agregation.
    */
-  getAllIssuesId(excludeClosed: boolean): Promise<Issue[]>;
+  getAllIssues(excludeClosed: boolean): Promise<Issue[]>;
 }
 
 export interface ILogger {

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -45,6 +45,7 @@ export class Synchronizer {
       this.logger.notice("No issues found");
       return false;
     }
+    this.logger.info(`Updating ${issues.length} issues`);
     const issueAssigment = await this.projectKit.assignIssues(issues);
     return issueAssigment.every((s) => s);
   }

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -17,7 +17,7 @@ export class Synchronizer {
     private readonly issueKit: IIssues,
     private readonly projectKit: IProjectApi,
     private readonly logger: ILogger,
-  ) { }
+  ) {}
 
   async synchronizeIssue(context: GitHubContext): Promise<boolean> {
     if (context.eventName === "workflow_dispatch") {
@@ -41,6 +41,10 @@ export class Synchronizer {
 
   async updateAllIssues(excludeClosed: boolean = false): Promise<boolean> {
     const issues = await this.issueKit.getAllIssues(excludeClosed);
+    if (issues?.length === 0) {
+      this.logger.notice("No issues found");
+      return false;
+    }
     const issueAssigment = await this.projectKit.assignIssues(issues);
     return issueAssigment.every((s) => s);
   }

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -17,7 +17,7 @@ export class Synchronizer {
     private readonly issueKit: IIssues,
     private readonly projectKit: IProjectApi,
     private readonly logger: ILogger,
-  ) {}
+  ) { }
 
   async synchronizeIssue(context: GitHubContext): Promise<boolean> {
     if (context.eventName === "workflow_dispatch") {
@@ -40,10 +40,9 @@ export class Synchronizer {
   }
 
   async updateAllIssues(excludeClosed: boolean = false): Promise<boolean> {
-    const issuesIds = await this.issueKit.getAllIssuesId(excludeClosed);
-    const updatePromises = issuesIds.map((nodeId) => this.projectKit.assignIssue(nodeId));
-    const syncs = await Promise.all(updatePromises);
-    return syncs.every((s) => s);
+    const issues = await this.issueKit.getAllIssues(excludeClosed);
+    const issueAssigment = await this.projectKit.assignIssues(issues);
+    return issueAssigment.every((s) => s);
   }
 
   async updateOneIssue(issue: Issue): Promise<boolean> {

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -3,7 +3,7 @@ import { validate } from "@octokit/graphql-schema";
 import {
   ADD_PROJECT_V2_ITEM_BY_ID_QUERY,
   PROJECT_V2_QUERY,
-  UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY,
+  UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY,
 } from "src/github/projectKit";
 
 describe("Schemas", () => {
@@ -15,7 +15,7 @@ describe("Schemas", () => {
     expect(validate(ADD_PROJECT_V2_ITEM_BY_ID_QUERY)).toEqual([]);
   });
 
-  test("UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY", () => {
-    expect(validate(UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY)).toEqual([]);
+  test("UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY", () => {
+    expect(validate(UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY)).toEqual([]);
   });
 });

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -1,0 +1,21 @@
+import { validate } from "@octokit/graphql-schema";
+
+import {
+  ADD_PROJECT_V2_ITEM_BY_ID_QUERY,
+  PROJECT_V2_QUERY,
+  UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY,
+} from "src/github/projectKit";
+
+describe("Schemas", () => {
+  test("PROJECT_V2_QUERY", () => {
+    expect(validate(PROJECT_V2_QUERY)).toEqual([]);
+  });
+
+  test("ADD_PROJECT_V2_ITEM_BY_ID_QUERY", () => {
+    expect(validate(ADD_PROJECT_V2_ITEM_BY_ID_QUERY)).toEqual([]);
+  });
+
+  test("UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY", () => {
+    expect(validate(UPDATE_PROJECT_NEXT_ITEM_FIELD_QUERY)).toEqual([]);
+  });
+});

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -32,14 +32,14 @@ describe("Synchronizer tests", () => {
   });
 
   test("should log when all issues will be synced", async () => {
-    issueKit.getAllIssuesId.mockReturnValue(Promise.resolve([]));
+    issueKit.getAllIssues.mockReturnValue(Promise.resolve([]));
     await synchronizer.synchronizeIssue({ eventName: "workflow_dispatch", payload: {} });
 
     expect(logger.notice).toBeCalledWith("Closed issues will be synced.");
   });
 
   test("should log when only open issues will be synced", async () => {
-    issueKit.getAllIssuesId.mockReturnValue(Promise.resolve([]));
+    issueKit.getAllIssues.mockReturnValue(Promise.resolve([]));
     await synchronizer.synchronizeIssue({
       eventName: "workflow_dispatch",
       payload: { inputs: { excludeClosed: "true" } },
@@ -59,16 +59,15 @@ describe("Synchronizer tests", () => {
     projectKit.assignIssue.calledWith({ node_id: "1234321", number: issueNumber });
   });
 
-  test("should call project.assignIssue over an iteration", async () => {
+  test("should call project.assignIssues with an iteration", async () => {
     const issues: Issue[] = [
       { number: 123, node_id: "asd_dsa" },
       { number: 987, node_id: "poi_lkj" },
     ];
-    issueKit.getAllIssuesId.mockReturnValue(Promise.resolve(issues));
+    issueKit.getAllIssues.mockReturnValue(Promise.resolve(issues));
+    projectKit.assignIssues.mockReturnValue(Promise.resolve([true, true]));
     await synchronizer.synchronizeIssue({ eventName: "workflow_dispatch", payload: {} });
 
-    issues.forEach((i) => {
-      projectKit.assignIssue.calledWith(i);
-    });
+    projectKit.assignIssues.calledWith(issues);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,6 +684,14 @@
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
 
+"@octokit/graphql-schema@^12.41.1":
+  version "12.41.1"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql-schema/-/graphql-schema-12.41.1.tgz#c3403e656f68a7f20cedef477fa22d8c22646d4d"
+  integrity sha512-OarIOf1FXbapMTmZ6NDdairuzqmsa0Y9tvbqjTFJJuyzz6kH1EgzpMEXWHeQaP1Oi3WR76hPqQanBmoQhTPzXA==
+  dependencies:
+    graphql "^16.0.0"
+    graphql-tag "^2.10.3"
+
 "@octokit/graphql@^4.5.8":
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
@@ -2021,6 +2029,18 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz#9cf3a665c6247479896834af35cf1dbb4400767e"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphql-tag@^2.10.3:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
+graphql@^16.0.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
@@ -3449,6 +3469,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Updated GraphQL queries to support version 2 as `ProjectNext` has been deprecated.

Moved all the queries to be stored in a exported variables so they can be accessed from outside.

Created unit tests which validates the schemas using `@octokit/graphql-schema` which contains the latest schemas. 

Modified dependabot to keep the `@octokit/graphql-schema` dependency at its latest.

This commit closes #46.