### PR TITLE
feat: added custom field support assigment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,11 @@ inputs:
     required: true
     description: The number of the project which the issues will be synced to
     type: number
-  project-field:
+  project_field:
     required: false
     description: The name of the project field which the issue will be assigned to
     type: string
-  project-value:
+  project_value:
     required: false
     description: The value which will be set in the field
     type: string

--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,11 @@ inputs:
     type: number
   project_field:
     required: false
-    description: The name of the project field which the issue will be assigned to
+    description: The name of the project field that will be set to project_value
     type: string
   project_value:
     required: false
-    description: The value which will be set in the field
+    description: The value which will be set in the project_field
     type: string
   GITHUB_TOKEN:
     required: true

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,16 @@ branding:
 inputs:
   project:
     required: true
+    description: The number of the project which the issues will be synced to
     type: number
+  project-field:
+    required: false
+    description: The name of the project field which the issue will be assigned to
+    type: string
+  project-value:
+    required: false
+    description: The value which will be set in the field
+    type: string
   GITHUB_TOKEN:
     required: true
     type: string

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@octokit/graphql-schema": "^12.41.1",
-    "@types/jest": "^29.2.5",
+    "@types/jest": "^29.2.6",
     "jest": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "opstooling-js-style": "https://github.com/paritytech/opstooling-js-style#c298d0f732d93712e4397fd53baa3317a3022c8c",

--- a/src/github/CoreLogger.ts
+++ b/src/github/CoreLogger.ts
@@ -7,7 +7,7 @@ export class CoreLogger implements ILogger {
   info(message: string): void {
     core.info(message);
   }
-  warning(message: string): void {
+  warning(message: string | Error): void {
     core.warning(message);
   }
   error(message: string | Error): void {

--- a/src/github/projectKit.ts
+++ b/src/github/projectKit.ts
@@ -75,6 +75,8 @@ export class ProjectKit implements IProjectApi {
         targetField: fields.field,
         targetFieldValue: fields.value,
       });
+
+      this.logger.debug("Returned " + JSON.stringify(op));
     } catch (e) {
       this.logger.error("Failed while executing the 'UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY' query");
       throw e;

--- a/src/github/projectKit.ts
+++ b/src/github/projectKit.ts
@@ -30,7 +30,7 @@ export const PROJECT_FIELD_ID_QUERY: string = `
 query($project: ID!) {
   node(id: $project) {
     ... on ProjectV2 {
-      fields(first: 20) {
+      fields(first: 20) { 
         nodes {
           ... on ProjectV2Field {
             id
@@ -112,8 +112,7 @@ export class ProjectKit implements IProjectApi {
 
       this.logger.debug("Returned " + JSON.stringify(op));
     } catch (e) {
-      this.logger.error("Failed while executing the 'UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY' query");
-      throw e;
+      throw new Error("Failed while executing the 'UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY' query", { cause: e });
     }
   }
 
@@ -150,8 +149,7 @@ export class ProjectKit implements IProjectApi {
 
       return projectData.organization.projectV2;
     } catch (e) {
-      this.logger.error("Failed while executing the 'PROJECT_V2_QUERY' query");
-      throw e;
+      throw new Error("Failed while executing the 'PROJECT_V2_QUERY' query", { cause: e });
     }
   }
 
@@ -173,8 +171,7 @@ export class ProjectKit implements IProjectApi {
 
       return migration.addProjectV2ItemById.item.id;
     } catch (e) {
-      this.logger.error("Failed while executing 'ADD_PROJECT_V2_ITEM_BY_ID_QUERY' query");
-      throw e;
+      throw new Error("Failed while executing 'ADD_PROJECT_V2_ITEM_BY_ID_QUERY' query", { cause: e });
     }
   }
 

--- a/src/github/projectKit.ts
+++ b/src/github/projectKit.ts
@@ -3,6 +3,7 @@ import { graphql } from "@octokit/graphql";
 import { ILogger, IProjectApi, Issue, Repository } from "./types";
 
 type NodeData = { id: string; title: string };
+type ProjectFields = { field: string; value: string };
 
 export const PROJECT_V2_QUERY: string = `
 query($organization: String!, $number: Int!) {
@@ -63,6 +64,7 @@ export class ProjectKit implements IProjectApi {
     private readonly repoData: Repository,
     private readonly projectNumber: number,
     private readonly logger: ILogger,
+    private readonly projectFields?: ProjectFields,
   ) {}
 
   /* 

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -34,7 +34,7 @@ export interface IIssues {
 
 export interface ILogger {
   info(message: string): void;
-  warning(message: string): void;
+  warning(message: string | Error): void;
   error(message: string | Error): void;
   /** Only posts messages if the action is ran in debug mode */
   debug(message: string): void;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -2,20 +2,32 @@ export type Repository = { owner: string; repo: string };
 
 export type Issue = { number: number; node_id: string };
 
+/** Key value pair with the name/id of a field and the name/id of its value */
+export type FieldValues = { field: string; value: string };
+
+export type NodeData = { id: string; title: string };
+
 export interface IProjectApi {
+  /**
+   * Fetches the node id from the project id and caches it.
+   * @returns node_id of the project. This value never changes so caching it per instance is effective
+   */
+  fetchProjectData(): Promise<NodeData>;
   /**
    * Assign an issue to a project
    * @param issue The issue object which has the number and the node_id
    */
-  assignIssue(issue: Issue): Promise<boolean>;
-
+  assignIssue(issue: Issue, project: NodeData, field?: FieldValues): Promise<string>;
   /**
-   * Assign several issues to a project
-   * @param issues The issue object collection which has the number and the node_id
+   * Fetches the available fields for a project board and filters to find the node ids of the field and value
+   * If either the field or the value don't exist, it will fail with an exception
+   * @param project The node data of the project
+   * @param projectFields The literal names of the fields to be modified
+   * @returns The id of both the field and the value
    */
-  assignIssues(issues: Issue[]): Promise<boolean[]>;
+  fetchProjectFieldNodeValues(project: NodeData, projectFields?: FieldValues): Promise<FieldValues>;
   // getProjectIdFromIssue(issueId: number): Promise<number>;
-  // changeIssueStateInProject(issueId: number, state: "todo" | "in progress" | "blocked" | "done"): Promise<boolean>;
+  changeIssueStateInProject(issueCardId: string, project: NodeData, fields: FieldValues): Promise<void>;
 }
 
 /** Class managing the instance of issues */

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -16,6 +16,8 @@ export interface IProjectApi {
   /**
    * Assign an issue to a project
    * @param issue The issue object which has the number and the node_id
+   * @returns the issueCardId of the created issue. This ID is used in changeIssueStateInProject.
+   * @see changeIssueStateInProject
    */
   assignIssue(issue: Issue, project: NodeData): Promise<string>;
   /**

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -17,7 +17,7 @@ export interface IProjectApi {
    * Assign an issue to a project
    * @param issue The issue object which has the number and the node_id
    */
-  assignIssue(issue: Issue, project: NodeData, field?: FieldValues): Promise<string>;
+  assignIssue(issue: Issue, project: NodeData): Promise<string>;
   /**
    * Fetches the available fields for a project board and filters to find the node ids of the field and value
    * If either the field or the value don't exist, it will fail with an exception

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,10 @@ const generateSynchronizer = (): Synchronizer => {
   const issueKit = new IssueApi(kit, repo);
   const projectGraphQl = getOctokit(orgToken).graphql.defaults({ headers: { authorization: `token ${orgToken}` } });
   const logger = new CoreLogger();
-  const projectKit = new ProjectKit(projectGraphQl, repo, projectNumber, logger, { field: projectField, value: projectValue });
+  const projectKit = new ProjectKit(projectGraphQl, repo, projectNumber, logger, {
+    field: projectField,
+    value: projectValue,
+  });
 
   return new Synchronizer(issueKit, projectKit, logger);
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ const generateSynchronizer = (): Synchronizer => {
   const orgToken = getInput("PROJECT_TOKEN", { required: true });
 
   const projectNumber = parseInt(getInput("project", { required: true }));
-  const projectFields = getProjectFieldValues();
 
   const { repo } = context;
 
@@ -33,11 +32,12 @@ const generateSynchronizer = (): Synchronizer => {
   const logger = new CoreLogger();
   const projectKit = new ProjectKit(projectGraphQl, repo, projectNumber, logger);
 
-  return new Synchronizer(issueKit, projectKit, logger, projectFields);
+  return new Synchronizer(issueKit, projectKit, logger);
 };
 
 const synchronizer = generateSynchronizer();
 
+const projectFields = getProjectFieldValues();
 const { issue } = context.payload;
 const parsedContext: GitHubContext = {
   eventName: context.eventName,
@@ -46,6 +46,7 @@ const parsedContext: GitHubContext = {
     inputs: context.payload.inputs,
     issue: issue ? { number: issue.number, node_id: issue.node_id as string } : undefined,
   },
+  config: { customField: projectFields },
 };
 
 synchronizer

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,7 +46,7 @@ const parsedContext: GitHubContext = {
     inputs: context.payload.inputs,
     issue: issue ? { number: issue.number, node_id: issue.node_id as string } : undefined,
   },
-  config: { customField: projectFields },
+  config: { projectField: projectFields },
 };
 
 synchronizer

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { debug, error, getInput, info, setFailed } from "@actions/core";
+import { debug, getInput, info, setFailed } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 
 import { CoreLogger } from "./github/CoreLogger";
@@ -51,11 +51,7 @@ const parsedContext: GitHubContext = {
 
 synchronizer
   .synchronizeIssue(parsedContext)
-  .then((result) => {
-    if (result) {
-      info("Operation finished successfully!");
-    } else {
-      error("There was a problem. Check logs for more information!");
-    }
+  .then(() => {
+    info("Operation finished successfully!");
   })
   .catch(setFailed);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,8 @@ const generateSynchronizer = (): Synchronizer => {
 
   const projectNumber = parseInt(getInput("project", { required: true }));
   // TODO: Add support for custom project fields (https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields)
+  const projectField = getInput("project-field");
+  const projectValue = getInput("project-value");
 
   const { repo } = context;
 
@@ -20,7 +22,7 @@ const generateSynchronizer = (): Synchronizer => {
   const issueKit = new IssueApi(kit, repo);
   const projectGraphQl = getOctokit(orgToken).graphql.defaults({ headers: { authorization: `token ${orgToken}` } });
   const logger = new CoreLogger();
-  const projectKit = new ProjectKit(projectGraphQl, repo, projectNumber, logger);
+  const projectKit = new ProjectKit(projectGraphQl, repo, projectNumber, logger, { field: projectField, value: projectValue });
 
   return new Synchronizer(issueKit, projectKit, logger);
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { debug, getInput, info, setFailed } from "@actions/core";
+import { debug, error, getInput, info, setFailed } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 
 import { CoreLogger } from "./github/CoreLogger";
@@ -49,9 +49,24 @@ const parsedContext: GitHubContext = {
   config: { projectField: projectFields },
 };
 
+const errorHandler = (e: Error) => {
+  let er = e;
+  setFailed(e);
+  while (er !== null) {
+    debug(`Stack -> ${er.stack as string}`);
+    if (er.cause != null) {
+      debug("Error has a nested error. Displaying.");
+      er = er.cause as Error;
+      error(er);
+    } else {
+      break;
+    }
+  }
+};
+
 synchronizer
   .synchronizeIssue(parsedContext)
   .then(() => {
     info("Operation finished successfully!");
   })
-  .catch(setFailed);
+  .catch(errorHandler);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { getInput, info, setFailed } from "@actions/core";
+import { debug, getInput, info, setFailed } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 
 import { CoreLogger } from "./github/CoreLogger";
@@ -13,8 +13,12 @@ const generateSynchronizer = (): Synchronizer => {
 
   const projectNumber = parseInt(getInput("project", { required: true }));
   // TODO: Add support for custom project fields (https://docs.github.com/en/issues/planning-and-tracking-with-projects/understanding-fields)
-  const projectField = getInput("project-field");
-  const projectValue = getInput("project-value");
+  const projectField = getInput("project_field");
+  const projectValue = getInput("project_value");
+  debug(`Values are: projectField: '${projectField}', projectValue: '${projectValue}'`);
+  if (!projectField && !projectValue) {
+    throw new Error("VALUES ARE EMPTY!");
+  }
 
   const { repo } = context;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { debug, getInput, info, setFailed } from "@actions/core";
+import { debug, error, getInput, info, setFailed } from "@actions/core";
 import { context, getOctokit } from "@actions/github";
 
 import { CoreLogger } from "./github/CoreLogger";
@@ -31,9 +31,9 @@ const generateSynchronizer = (): Synchronizer => {
   const issueKit = new IssueApi(kit, repo);
   const projectGraphQl = getOctokit(orgToken).graphql.defaults({ headers: { authorization: `token ${orgToken}` } });
   const logger = new CoreLogger();
-  const projectKit = new ProjectKit(projectGraphQl, repo, projectNumber, logger, projectFields);
+  const projectKit = new ProjectKit(projectGraphQl, repo, projectNumber, logger);
 
-  return new Synchronizer(issueKit, projectKit, logger);
+  return new Synchronizer(issueKit, projectKit, logger, projectFields);
 };
 
 const synchronizer = generateSynchronizer();
@@ -50,5 +50,11 @@ const parsedContext: GitHubContext = {
 
 synchronizer
   .synchronizeIssue(parsedContext)
-  .then(() => info("Finished"))
+  .then((result) => {
+    if (result) {
+      info("Operation finished successfully!");
+    } else {
+      error("There was a problem. Check logs for more information!");
+    }
+  })
   .catch(setFailed);

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -22,7 +22,7 @@ export class Synchronizer {
     private readonly logger: ILogger,
   ) {}
 
-  async synchronizeIssue(context: GitHubContext): Promise<boolean> {
+  async synchronizeIssue(context: GitHubContext): Promise<void> | never {
     if (context.eventName === "workflow_dispatch") {
       const excludeClosed = context.payload.inputs?.excludeClosed === "true";
       this.logger.notice(excludeClosed ? "Closed issues will NOT be synced." : "Closed issues will be synced.");
@@ -61,11 +61,10 @@ export class Synchronizer {
     }
   }
 
-  private async updateAllIssues(excludeClosed: boolean = false, customField?: FieldValues): Promise<boolean> {
+  private async updateAllIssues(excludeClosed: boolean = false, customField?: FieldValues): Promise<void> | never {
     const issues = await this.issueKit.getAllIssues(excludeClosed);
     if (issues?.length === 0) {
-      this.logger.notice("No issues found");
-      return false;
+      return this.logger.notice("No issues found");
     }
     this.logger.info(`Updating ${issues.length} issues`);
 
@@ -81,18 +80,14 @@ export class Synchronizer {
       );
       await Promise.all(assignCustomFieldPromise);
     }
-
-    return true;
   }
 
-  private async updateOneIssue(issue: Issue, customField?: FieldValues): Promise<boolean> {
+  private async updateOneIssue(issue: Issue, customField?: FieldValues): Promise<void> | never {
     const projectNode = await this.projectKit.fetchProjectData();
     const customFieldNodeData = await this.getCustomFieldNodeData(projectNode, customField);
     const issueCardId = await this.projectKit.assignIssue(issue, projectNode);
     if (customFieldNodeData) {
       await this.projectKit.changeIssueStateInProject(issueCardId, projectNode, customFieldNodeData);
     }
-
-    return true;
   }
 }

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -11,7 +11,7 @@ export type GitHubContext = {
     issue?: Issue;
   };
   config?: {
-    customField?: FieldValues;
+    projectField?: FieldValues;
   };
 };
 
@@ -26,7 +26,7 @@ export class Synchronizer {
     if (context.eventName === "workflow_dispatch") {
       const excludeClosed = context.payload.inputs?.excludeClosed === "true";
       this.logger.notice(excludeClosed ? "Closed issues will NOT be synced." : "Closed issues will be synced.");
-      return await this.updateAllIssues(excludeClosed, context.config?.customField);
+      return await this.updateAllIssues(excludeClosed, context.config?.projectField);
     } else if (context.eventName === "issues") {
       const { issue } = context.payload;
       if (!issue) {
@@ -34,7 +34,7 @@ export class Synchronizer {
       }
       this.logger.debug(`Received issue ${JSON.stringify(issue)}`);
       this.logger.info(`Assigning issue #${issue.number} to project`);
-      return await this.updateOneIssue(issue, context.config?.customField);
+      return await this.updateOneIssue(issue, context.config?.projectField);
     } else {
       const failMessage = `Event '${context.eventName}' is not expected. Failing.`;
       this.logger.warning(failMessage);

--- a/src/synchronizer.ts
+++ b/src/synchronizer.ts
@@ -57,8 +57,7 @@ export class Synchronizer {
     try {
       return await this.projectKit.fetchProjectFieldNodeValues(project, customField);
     } catch (e) {
-      this.logger.error("Failed fetching project values.");
-      throw e;
+      throw new Error("Failed fetching project values", { cause: e });
     }
   }
 

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -2,6 +2,7 @@ import { validate } from "@octokit/graphql-schema";
 
 import {
   ADD_PROJECT_V2_ITEM_BY_ID_QUERY,
+  PROJECT_FIELD_ID_QUERY,
   PROJECT_V2_QUERY,
   UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY,
 } from "src/github/projectKit";
@@ -17,5 +18,9 @@ describe("Schemas", () => {
 
   test("UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY", () => {
     expect(validate(UPDATE_PROJECT_V2_ITEM_FIELD_VALUE_QUERY)).toEqual([]);
+  });
+
+  test("PROJECT_FIELD_ID_QUERY", () => {
+    expect(validate(PROJECT_FIELD_ID_QUERY)).toEqual([]);
   });
 });

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -55,7 +55,7 @@ describe("Synchronizer tests", () => {
     let ctx: GitHubContext;
     let issueNumber: number;
     beforeEach(() => {
-      issueNumber = Math.floor(Math.random() * 100);
+      issueNumber = 123;
       nodeData = { id: new Date().toDateString(), title: "Update one issue" };
       ctx = { eventName: "issues", payload: { issue: { node_id: "update_one_issue", number: issueNumber } } };
       projectKit.fetchProjectData.mockResolvedValue(nodeData);

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -93,8 +93,7 @@ describe("Synchronizer tests", () => {
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
       await expect(
         synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "c", value: "d" } } }),
-      ).rejects.toThrow();
-      expect(logger.error).toBeCalledWith("Failed fetching project values.");
+      ).rejects.toThrow("Failed fetching project values");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
     });
   });
@@ -173,8 +172,7 @@ describe("Synchronizer tests", () => {
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
       await expect(
         synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "k", value: "y" } } }),
-      ).rejects.toThrow();
-      expect(logger.error).toBeCalledWith("Failed fetching project values.");
+      ).rejects.toThrow("Failed fetching project values");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
     });
   });

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -67,8 +67,8 @@ describe("Synchronizer tests", () => {
       expect(projectKit.assignIssue).toBeCalledWith(ctx.payload.issue, nodeData);
     });
 
-    test("should return true on correct execution", async () => {
-      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
+    test("should not throw on correct execution", async () => {
+      await synchronizer.synchronizeIssue(ctx);
       expect(logger.info).toBeCalledWith(`Assigning issue #${issueNumber} to project`);
     });
 
@@ -83,9 +83,7 @@ describe("Synchronizer tests", () => {
       projectKit.fetchProjectFieldNodeValues.mockResolvedValue(nodeValueData);
       const issueCardNodeId = "issue_node_id_example";
       projectKit.assignIssue.mockResolvedValue(issueCardNodeId);
-      expect(
-        await synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "c", value: "d" } } }),
-      ).toBeTruthy();
+      await synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "c", value: "d" } } });
       expect(projectKit.changeIssueStateInProject).toBeCalledWith(issueCardNodeId, nodeData, nodeValueData);
     });
 
@@ -112,13 +110,6 @@ describe("Synchronizer tests", () => {
       expect(logger.notice).toBeCalledWith("No issues found");
     });
 
-    test("should return true in correct execution", async () => {
-      const issues: Issue[] = [{ number: 1, node_id: "asd_dsa" }];
-
-      issueKit.getAllIssues.mockResolvedValue(issues);
-      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
-    });
-
     test("should call assign Issues with an iteration", async () => {
       const issues: Issue[] = [
         { number: 1, node_id: "asd_dsa" },
@@ -128,7 +119,7 @@ describe("Synchronizer tests", () => {
       ];
 
       issueKit.getAllIssues.mockResolvedValue(issues);
-      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
+      await synchronizer.synchronizeIssue(ctx);
 
       for (let i = 0; i < issues.length; i++) {
         expect(projectKit.assignIssue).toHaveBeenNthCalledWith(i + 1, issues[i], nodeData);

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { mock, mockReset } from "jest-mock-extended";
 
-import { IIssues, ILogger, IProjectApi, Issue } from "src/github/types";
-import { Synchronizer } from "src/synchronizer";
+import { IIssues, ILogger, IProjectApi, Issue, NodeData } from "src/github/types";
+import { GitHubContext, Synchronizer } from "src/synchronizer";
 
 describe("Synchronizer tests", () => {
   const issueKit = mock<IIssues>();
@@ -17,59 +17,165 @@ describe("Synchronizer tests", () => {
     synchronizer = new Synchronizer(issueKit, projectKit, logger);
   });
 
-  test("should fail on invalid event name", async () => {
-    const randomEventName = new Date().toDateString();
-    const expectedError = `Event '${randomEventName}' is not expected. Failing.`;
-    await expect(synchronizer.synchronizeIssue({ eventName: randomEventName, payload: {} })).rejects.toThrow(
-      expectedError,
-    );
-  });
-
-  test("should fail on issue event without payload", async () => {
-    await expect(synchronizer.synchronizeIssue({ eventName: "issues", payload: {} })).rejects.toThrow(
-      "Issue payload object was null",
-    );
-  });
-
-  test("should log when all issues will be synced", async () => {
-    issueKit.getAllIssues.mockReturnValue(Promise.resolve([]));
-    await synchronizer.synchronizeIssue({ eventName: "workflow_dispatch", payload: {} });
-
-    expect(logger.notice).toBeCalledWith("Closed issues will be synced.");
-  });
-
-  test("should log when only open issues will be synced", async () => {
-    issueKit.getAllIssues.mockReturnValue(Promise.resolve([]));
-    await synchronizer.synchronizeIssue({
-      eventName: "workflow_dispatch",
-      payload: { inputs: { excludeClosed: "true" } },
+  describe("synchronize Issues function", () => {
+    test("should fail on invalid event name", async () => {
+      const randomEventName = new Date().toDateString();
+      const expectedError = `Event '${randomEventName}' is not expected. Failing.`;
+      await expect(synchronizer.synchronizeIssue({ eventName: randomEventName, payload: {} })).rejects.toThrow(
+        expectedError,
+      );
     });
 
-    expect(logger.notice).toBeCalledWith("Closed issues will NOT be synced.");
-  });
-
-  test("should invoke project.assignIssue", async () => {
-    const issueNumber = Math.floor(Math.random() * 100);
-    const nodeData = { id: "id", title: "title" };
-    projectKit.fetchProjectData.mockResolvedValue(nodeData);
-    await synchronizer.synchronizeIssue({
-      eventName: "issues",
-      payload: { issue: { node_id: "1234321", number: issueNumber } },
+    test("should fail on issue event without payload", async () => {
+      await expect(synchronizer.synchronizeIssue({ eventName: "issues", payload: {} })).rejects.toThrow(
+        "Issue payload object was null",
+      );
     });
 
-    logger.info.calledWith(`Assigning issue #${issueNumber} to project`);
-    projectKit.assignIssue.calledWith({ node_id: "1234321", number: issueNumber }, nodeData);
+    test("should log when all issues will be synced", async () => {
+      issueKit.getAllIssues.mockResolvedValue([]);
+      await synchronizer.synchronizeIssue({ eventName: "workflow_dispatch", payload: {} });
+
+      expect(logger.notice).toBeCalledWith("Closed issues will be synced.");
+    });
+
+    test("should log when only open issues will be synced", async () => {
+      issueKit.getAllIssues.mockResolvedValue([]);
+      await synchronizer.synchronizeIssue({
+        eventName: "workflow_dispatch",
+        payload: { inputs: { excludeClosed: "true" } },
+      });
+
+      expect(logger.notice).toBeCalledWith("Closed issues will NOT be synced.");
+    });
   });
 
-  test("should call project.assignIssues with an iteration", async () => {
-    const issues: Issue[] = [
-      { number: 123, node_id: "asd_dsa" },
-      { number: 987, node_id: "poi_lkj" },
-    ];
-    issueKit.getAllIssues.mockResolvedValue(issues);
-    projectKit.assignIssue.mockResolvedValue("");
-    await synchronizer.synchronizeIssue({ eventName: "workflow_dispatch", payload: {} });
+  describe("update one issue", () => {
+    let nodeData: NodeData;
+    let ctx: GitHubContext;
+    let issueNumber: number;
+    beforeEach(() => {
+      issueNumber = Math.floor(Math.random() * 100);
+      nodeData = { id: new Date().toDateString(), title: "Update one issue" };
+      ctx = { eventName: "issues", payload: { issue: { node_id: "update_one_issue", number: issueNumber } } };
+      projectKit.fetchProjectData.mockResolvedValue(nodeData);
+    });
 
-    // projectKit.assignIssue.calledWith("");
+    test("should invoke using the correct node data", async () => {
+      await synchronizer.synchronizeIssue(ctx);
+      expect(logger.info).toBeCalledWith(`Assigning issue #${issueNumber} to project`);
+      expect(projectKit.assignIssue).toBeCalledWith(ctx.payload.issue, nodeData);
+    });
+
+    test("should return true on correct execution", async () => {
+      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
+      expect(logger.info).toBeCalledWith(`Assigning issue #${issueNumber} to project`);
+    });
+
+    test("should fetch custom fields data", async () => {
+      const [field, value] = ["a", "B"];
+      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field, value });
+      await synchronizer.synchronizeIssue(ctx);
+      expect(projectKit.fetchProjectFieldNodeValues).toBeCalledWith(nodeData, { field, value });
+    });
+
+    test("should assign custom fields", async () => {
+      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "c", value: "d" });
+      const nodeValueData = { field: "eee", value: "fff" };
+      projectKit.fetchProjectFieldNodeValues.mockResolvedValue(nodeValueData);
+      const issueCardNodeId = "issue_node_id_example";
+      projectKit.assignIssue.mockResolvedValue(issueCardNodeId);
+      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
+      expect(projectKit.changeIssueStateInProject).toBeCalledWith(issueCardNodeId, nodeData, nodeValueData);
+    });
+
+    test("should return false on error while assigning custom field", async () => {
+      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "c", value: "d" });
+      projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
+      expect(await synchronizer.synchronizeIssue(ctx)).toBeFalsy();
+      expect(logger.notice).toBeCalledWith("Failed fetching project values. Skipping project field assignment.");
+      expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
+    });
+  });
+  describe("update all issues", () => {
+    let nodeData: NodeData;
+    let ctx: GitHubContext;
+    beforeEach(() => {
+      nodeData = { id: new Date().toDateString(), title: "Update all issues" };
+      ctx = { eventName: "workflow_dispatch", payload: {} };
+      projectKit.fetchProjectData.mockResolvedValue(nodeData);
+    });
+
+    test("should report when no issues are available", async () => {
+      issueKit.getAllIssues.mockResolvedValue([]);
+      expect(await synchronizer.synchronizeIssue(ctx)).toBeFalsy();
+      expect(logger.notice).toBeCalledWith("No issues found");
+    });
+
+    test("should return true in correct execution", async () => {
+      const issues: Issue[] = [{ number: 1, node_id: "asd_dsa" }];
+
+      issueKit.getAllIssues.mockResolvedValue(issues);
+      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
+    });
+
+    test("should call assign Issues with an iteration", async () => {
+      const issues: Issue[] = [
+        { number: 1, node_id: "asd_dsa" },
+        { number: 2, node_id: "poi_lkj" },
+        { number: 3, node_id: "grs_Dfr" },
+        { number: 4, node_id: "hor_2dg" },
+      ];
+
+      issueKit.getAllIssues.mockResolvedValue(issues);
+      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
+
+      for (let i = 0; i < issues.length; i++) {
+        expect(projectKit.assignIssue).toHaveBeenNthCalledWith(i + 1, issues[i], nodeData);
+      }
+      expect(logger.debug).toBeCalledWith(`Finished assigning ${issues.length} issues`);
+    });
+
+    test("should fetch custom fields data", async () => {
+      const [field, value] = ["a", "B"];
+      issueKit.getAllIssues.mockResolvedValue([{ number: 999, node_id: "123_asd" }]);
+      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field, value });
+      await synchronizer.synchronizeIssue(ctx);
+      expect(projectKit.fetchProjectFieldNodeValues).toBeCalledWith(nodeData, { field, value });
+    });
+
+    test("should assign custom fields", async () => {
+      const issues: Issue[] = [
+        { number: 1, node_id: "asdw_dsa" },
+        { number: 2, node_id: "gers_Dfr" },
+        { number: 4, node_id: "hgor_2dg" },
+        { number: 8, node_id: "pdoi_lkj" },
+      ];
+      const nodeValueData = { field: "eee", value: "fff" };
+      issueKit.getAllIssues.mockResolvedValue(issues);
+      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "ooo", value: "iiii" });
+      projectKit.fetchProjectFieldNodeValues.mockResolvedValue(nodeValueData);
+
+      let index = 1;
+      projectKit.assignIssue
+        .mockResolvedValueOnce(`_${index++}`)
+        .mockResolvedValueOnce(`_${index++}`)
+        .mockResolvedValueOnce(`_${index++}`)
+        .mockResolvedValueOnce(`_${index++}`);
+
+      await synchronizer.synchronizeIssue(ctx);
+      for (let i = 1; i < issues.length; i++) {
+        expect(projectKit.changeIssueStateInProject).toHaveBeenNthCalledWith(i, `_${i}`, nodeData, nodeValueData);
+      }
+    });
+
+    test("should return false on error while assigning custom field", async () => {
+      issueKit.getAllIssues.mockResolvedValue([{ number: 999, node_id: "123_asd" }]);
+      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "k", value: "y" });
+      projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
+      expect(await synchronizer.synchronizeIssue(ctx)).toBeFalsy();
+      expect(logger.notice).toBeCalledWith("Failed fetching project values. Skipping project field assignment.");
+      expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -89,11 +89,11 @@ describe("Synchronizer tests", () => {
       expect(projectKit.changeIssueStateInProject).toBeCalledWith(issueCardNodeId, nodeData, nodeValueData);
     });
 
-    test("should return false on error while assigning custom field", async () => {
+    test("should throw error while assigning invalid custom field", async () => {
       synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "c", value: "d" });
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
-      expect(await synchronizer.synchronizeIssue(ctx)).toBeFalsy();
-      expect(logger.notice).toBeCalledWith("Failed fetching project values. Skipping project field assignment.");
+      await expect(synchronizer.synchronizeIssue(ctx)).rejects.toThrow();
+      expect(logger.error).toBeCalledWith("Failed fetching project values.");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
     });
   });
@@ -169,12 +169,12 @@ describe("Synchronizer tests", () => {
       }
     });
 
-    test("should return false on error while assigning custom field", async () => {
+    test("should throw error while assigning invalid custom field", async () => {
       issueKit.getAllIssues.mockResolvedValue([{ number: 999, node_id: "123_asd" }]);
       synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "k", value: "y" });
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
-      expect(await synchronizer.synchronizeIssue(ctx)).toBeFalsy();
-      expect(logger.notice).toBeCalledWith("Failed fetching project values. Skipping project field assignment.");
+      await expect(synchronizer.synchronizeIssue(ctx)).rejects.toThrow();
+      expect(logger.error).toBeCalledWith("Failed fetching project values.");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
     });
   });

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -74,7 +74,7 @@ describe("Synchronizer tests", () => {
 
     test("should fetch custom fields data", async () => {
       const [field, value] = ["a", "B"];
-      await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field, value } } });
+      await synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field, value } } });
       expect(projectKit.fetchProjectFieldNodeValues).toBeCalledWith(nodeData, { field, value });
     });
 
@@ -84,7 +84,7 @@ describe("Synchronizer tests", () => {
       const issueCardNodeId = "issue_node_id_example";
       projectKit.assignIssue.mockResolvedValue(issueCardNodeId);
       expect(
-        await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "c", value: "d" } } }),
+        await synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "c", value: "d" } } }),
       ).toBeTruthy();
       expect(projectKit.changeIssueStateInProject).toBeCalledWith(issueCardNodeId, nodeData, nodeValueData);
     });
@@ -92,7 +92,7 @@ describe("Synchronizer tests", () => {
     test("should throw error while assigning invalid custom field", async () => {
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
       await expect(
-        synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "c", value: "d" } } }),
+        synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "c", value: "d" } } }),
       ).rejects.toThrow();
       expect(logger.error).toBeCalledWith("Failed fetching project values.");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
@@ -140,7 +140,7 @@ describe("Synchronizer tests", () => {
     test("should fetch custom fields data", async () => {
       const [field, value] = ["a", "B"];
       issueKit.getAllIssues.mockResolvedValue([{ number: 999, node_id: "123_asd" }]);
-      await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field, value } } });
+      await synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field, value } } });
       expect(projectKit.fetchProjectFieldNodeValues).toBeCalledWith(nodeData, { field, value });
     });
 
@@ -162,7 +162,7 @@ describe("Synchronizer tests", () => {
         .mockResolvedValueOnce(`_${index++}`)
         .mockResolvedValueOnce(`_${index++}`);
 
-      await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "ooo", value: "iiii" } } });
+      await synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "ooo", value: "iiii" } } });
       for (let i = 1; i < issues.length; i++) {
         expect(projectKit.changeIssueStateInProject).toHaveBeenNthCalledWith(i, `_${i}`, nodeData, nodeValueData);
       }
@@ -172,7 +172,7 @@ describe("Synchronizer tests", () => {
       issueKit.getAllIssues.mockResolvedValue([{ number: 999, node_id: "123_asd" }]);
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
       await expect(
-        synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "k", value: "y" } } }),
+        synchronizer.synchronizeIssue({ ...ctx, config: { projectField: { field: "k", value: "y" } } }),
       ).rejects.toThrow();
       expect(logger.error).toBeCalledWith("Failed fetching project values.");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -74,25 +74,26 @@ describe("Synchronizer tests", () => {
 
     test("should fetch custom fields data", async () => {
       const [field, value] = ["a", "B"];
-      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field, value });
-      await synchronizer.synchronizeIssue(ctx);
+      await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field, value } } });
       expect(projectKit.fetchProjectFieldNodeValues).toBeCalledWith(nodeData, { field, value });
     });
 
     test("should assign custom fields", async () => {
-      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "c", value: "d" });
       const nodeValueData = { field: "eee", value: "fff" };
       projectKit.fetchProjectFieldNodeValues.mockResolvedValue(nodeValueData);
       const issueCardNodeId = "issue_node_id_example";
       projectKit.assignIssue.mockResolvedValue(issueCardNodeId);
-      expect(await synchronizer.synchronizeIssue(ctx)).toBeTruthy();
+      expect(
+        await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "c", value: "d" } } }),
+      ).toBeTruthy();
       expect(projectKit.changeIssueStateInProject).toBeCalledWith(issueCardNodeId, nodeData, nodeValueData);
     });
 
     test("should throw error while assigning invalid custom field", async () => {
-      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "c", value: "d" });
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
-      await expect(synchronizer.synchronizeIssue(ctx)).rejects.toThrow();
+      await expect(
+        synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "c", value: "d" } } }),
+      ).rejects.toThrow();
       expect(logger.error).toBeCalledWith("Failed fetching project values.");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
     });
@@ -139,8 +140,7 @@ describe("Synchronizer tests", () => {
     test("should fetch custom fields data", async () => {
       const [field, value] = ["a", "B"];
       issueKit.getAllIssues.mockResolvedValue([{ number: 999, node_id: "123_asd" }]);
-      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field, value });
-      await synchronizer.synchronizeIssue(ctx);
+      await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field, value } } });
       expect(projectKit.fetchProjectFieldNodeValues).toBeCalledWith(nodeData, { field, value });
     });
 
@@ -153,7 +153,6 @@ describe("Synchronizer tests", () => {
       ];
       const nodeValueData = { field: "eee", value: "fff" };
       issueKit.getAllIssues.mockResolvedValue(issues);
-      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "ooo", value: "iiii" });
       projectKit.fetchProjectFieldNodeValues.mockResolvedValue(nodeValueData);
 
       let index = 1;
@@ -163,7 +162,7 @@ describe("Synchronizer tests", () => {
         .mockResolvedValueOnce(`_${index++}`)
         .mockResolvedValueOnce(`_${index++}`);
 
-      await synchronizer.synchronizeIssue(ctx);
+      await synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "ooo", value: "iiii" } } });
       for (let i = 1; i < issues.length; i++) {
         expect(projectKit.changeIssueStateInProject).toHaveBeenNthCalledWith(i, `_${i}`, nodeData, nodeValueData);
       }
@@ -171,9 +170,10 @@ describe("Synchronizer tests", () => {
 
     test("should throw error while assigning invalid custom field", async () => {
       issueKit.getAllIssues.mockResolvedValue([{ number: 999, node_id: "123_asd" }]);
-      synchronizer = new Synchronizer(issueKit, projectKit, logger, { field: "k", value: "y" });
       projectKit.fetchProjectFieldNodeValues.mockRejectedValue(new Error());
-      await expect(synchronizer.synchronizeIssue(ctx)).rejects.toThrow();
+      await expect(
+        synchronizer.synchronizeIssue({ ...ctx, config: { customField: { field: "k", value: "y" } } }),
+      ).rejects.toThrow();
       expect(logger.error).toBeCalledWith("Failed fetching project values.");
       expect(projectKit.changeIssueStateInProject).toHaveBeenCalledTimes(0);
     });

--- a/src/test/synchronizer.test.ts
+++ b/src/test/synchronizer.test.ts
@@ -50,13 +50,15 @@ describe("Synchronizer tests", () => {
 
   test("should invoke project.assignIssue", async () => {
     const issueNumber = Math.floor(Math.random() * 100);
+    const nodeData = { id: "id", title: "title" };
+    projectKit.fetchProjectData.mockResolvedValue(nodeData);
     await synchronizer.synchronizeIssue({
       eventName: "issues",
       payload: { issue: { node_id: "1234321", number: issueNumber } },
     });
 
     logger.info.calledWith(`Assigning issue #${issueNumber} to project`);
-    projectKit.assignIssue.calledWith({ node_id: "1234321", number: issueNumber });
+    projectKit.assignIssue.calledWith({ node_id: "1234321", number: issueNumber }, nodeData);
   });
 
   test("should call project.assignIssues with an iteration", async () => {
@@ -64,10 +66,10 @@ describe("Synchronizer tests", () => {
       { number: 123, node_id: "asd_dsa" },
       { number: 987, node_id: "poi_lkj" },
     ];
-    issueKit.getAllIssues.mockReturnValue(Promise.resolve(issues));
-    projectKit.assignIssues.mockReturnValue(Promise.resolve([true, true]));
+    issueKit.getAllIssues.mockResolvedValue(issues);
+    projectKit.assignIssue.mockResolvedValue("");
     await synchronizer.synchronizeIssue({ eventName: "workflow_dispatch", payload: {} });
 
-    projectKit.assignIssues.calledWith(issues);
+    // projectKit.assignIssue.calledWith("");
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,10 +899,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@^29.2.5":
-  version "29.2.5"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.2.5.tgz#c27f41a9d6253f288d1910d3c5f09484a56b73c0"
-  integrity sha512-H2cSxkKgVmqNHXP7TC2L/WUorrZu8ZigyRywfVzv6EyBlxj39n4C00hjXYQWsbwqgElaj/CiAeSRmk5GoaKTgw==
+"@types/jest@^29.2.6":
+  version "29.2.6"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.2.6.tgz#1d43c8e533463d0437edef30b2d45d5aa3d95b0a"
+  integrity sha512-XEUC/Tgw3uMh6Ho8GkUtQ2lPhY5Fmgyp3TdlkTJs1W9VgNxs+Ow/x3Elh8lHQKqCbZL0AubQuqWjHVT033Hhrw==
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"


### PR DESCRIPTION
Added the ability to add a custom project field when assigning an issue to a project.

This commit closes #44 

Moved more of the logic to the `synchronizer` and enhanced the tests to include those business logic changes.

Created an evaluated new GraphQL query for GitHub's project API.