### PR TITLE
feat: moved action to use GitHub Package Registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,3 +14,39 @@ jobs:
       - uses: actions/checkout@v3.3.0
       - name: Run tests
         run: docker build . --file Dockerfile
+
+  tag:
+    if: github.event_name == 'push'
+    needs: [test-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tagcreated: ${{ steps.autotag.outputs.tagcreated }}
+      tagname: ${{ steps.autotag.outputs.tagname }}
+    steps:
+      - uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+      - uses: butlerlogic/action-autotag@stable
+        id: autotag
+        with:
+          head_branch: master
+          tag_prefix: "v"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Changelog
+        uses: Bullrich/generate-release-changelog@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+      - name: Create Release
+        if: steps.autotag.outputs.tagname != ''
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.autotag.outputs.tagname }}
+          release_name: Release ${{ steps.autotag.outputs.tagname }}
+          body: |
+            ${{ steps.Changelog.outputs.changelog }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Changelog
-        uses: Bullrich/generate-release-changelog@master
+        uses: Bullrich/generate-release-changelog@2.0.2
         id: Changelog
         env:
           REPO: ${{ github.repository }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.3.0
-      - name: Run tests
+      - name: Check that the image builds
         run: docker build . --file Dockerfile
 
   test-versions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+name: Publish package to GitHub Packages
 on:
   push:
     branches:
@@ -50,3 +51,39 @@ jobs:
           release_name: Release ${{ steps.autotag.outputs.tagname }}
           body: |
             ${{ steps.Changelog.outputs.changelog }}
+
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    needs: [tag]
+    if: needs.tag.outputs.tagname != ''
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ ! -z $TAG ]] && VERSION=$(echo $TAG | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+        env:
+          TAG: ${{ needs.tag.outputs.tagname }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  IMAGE_NAME: action
+
+jobs:
+  test-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: Run tests
+        run: docker build . --file Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,35 @@ jobs:
       - name: Run tests
         run: docker build . --file Dockerfile
 
+  test-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.3.0
+      - name: Extract package.json version
+        id: package_version
+        run: echo "VERSION=$(jq '.version' -r package.json)" >> $GITHUB_OUTPUT
+      - name: Extract action.yml version
+        uses: mikefarah/yq@master
+        id: action_image
+        with:
+          cmd: yq '.runs.image' 'action.yml'
+      - name: Parse action.yml version
+        id: action_version
+        run: |
+          echo "IMAGE_VERSION=$(echo $IMAGE_URL | cut -d: -f3)" >> $GITHUB_OUTPUT
+        env:
+          IMAGE_URL: ${{ steps.action_image.outputs.result }}
+      - name: Compare versions
+        run: |
+          echo "Verifying that $IMAGE_VERSION from action.yml is the same as $PACKAGE_VERSION from package.json"
+          [[ $IMAGE_VERSION == $PACKAGE_VERSION ]]
+        env:
+          IMAGE_VERSION: ${{ steps.action_version.outputs.IMAGE_VERSION }}
+          PACKAGE_VERSION: ${{ steps.package_version.outputs.VERSION }}
+
   tag:
     if: github.event_name == 'push'
-    needs: [test-image]
+    needs: [test-image, test-versions]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:18 as Builder
 
 WORKDIR /action
 
-RUN npm i -g @vercel/ncc
-
 COPY package.json yarn.lock ./
 
 RUN yarn install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:18
+FROM node:18 as Builder
+
+WORKDIR /action
+
+RUN npm i -g @vercel/ncc
 
 COPY package.json yarn.lock ./
 
@@ -6,6 +10,10 @@ RUN yarn install --frozen-lockfile
 
 COPY . .
 
-RUN yarn build
+RUN ncc build src/main.ts -o dist
 
-CMD ["yarn", "start"]
+FROM node:18-slim
+
+COPY --from=Builder /action/dist /action
+
+ENTRYPOINT ["node", "/action/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yarn install --frozen-lockfile
 
 COPY . .
 
-RUN ncc build src/main.ts -o dist
+RUN yarn build
 
 FROM node:18-slim
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # Introduction
 
+![Publish](https://github.com/paritytech/github-issue-sync/actions/workflows/publish.yml/badge.svg?branch=master)
+
 This project enables syncing GitHub Issues to a [GitHub Project](https://docs.github.com/en/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects).
 
 ## Why is this necessary?

--- a/action.yml
+++ b/action.yml
@@ -29,4 +29,4 @@ inputs:
     type: string
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/bullrich/github-issue-sync/example:0.3.1'

--- a/action.yml
+++ b/action.yml
@@ -29,4 +29,4 @@ inputs:
     type: string
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/bullrich/github-issue-sync/example:0.3.1'
+  image: 'docker://ghcr.io/paritytech/github-issue-sync/example:0.3.1'

--- a/action.yml
+++ b/action.yml
@@ -29,4 +29,4 @@ inputs:
     type: string
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/github-issue-sync/example:0.3.1'
+  image: 'docker://ghcr.io/paritytech/github-issue-sync/action:0.3.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-issue-sync",
-  "version": "0.0.1",
+  "version": "0.3.1",
   "description": "Synchronize issues to GitHub Project boards",
   "author": "Parity <admin@parity.io> (https://parity.io)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "url": "git+https://github.com/paritytech/github-issue-sync.git"
   },
   "license": "Apache-2.0",
-  "main": "dist/main.js",
+  "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
-    "start": "node --experimental-modules dist/main.js",
+    "build": "ncc build src/main.ts",
+    "start": "node --experimental-modules dist/index.js",
     "test": "jest",
     "typecheck": "tsc --noEmit",
     "fix:eslint": "eslint --fix",
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@octokit/graphql-schema": "^12.41.1",
     "@types/jest": "^29.2.6",
+    "@vercel/ncc": "^0.36.1",
     "jest": "^29.3.1",
     "jest-mock-extended": "^3.0.1",
     "opstooling-js-style": "https://github.com/paritytech/opstooling-js-style#c298d0f732d93712e4397fd53baa3317a3022c8c",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,6 +1032,11 @@
     "@typescript-eslint/types" "5.48.1"
     eslint-visitor-keys "^3.3.0"
 
+"@vercel/ncc@^0.36.1":
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.36.1.tgz#d4c01fdbbe909d128d1bf11c7f8b5431654c5b95"
+  integrity sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
Updated the project to store an already built image in the GitHub Package Registry.

This PR brings 3 changes:
- It creates a new release CI flow.
- It modifies the Docker image to be a multi step image.
- It changes the action definition file (`action.yml`) to use an image from the registry.

## The CI

The new CI workflow does the following:
- Checks that the Docker image can be built.
- Checks that the version for the package and the docker image are the same
- If the version in the `package.json` changed:
  - Tag the commit with the new version
  - Generate a new release (with a changelog)
  - Builds and publishes the docker image using the new tag

## The Dockerimage

As the image is being stored, I modified it to actually use a second slim version with the compiled code so it is smaller (and gets downloaded faster).